### PR TITLE
patch for MacOSX

### DIFF
--- a/src/argparse_formatter.cpp
+++ b/src/argparse_formatter.cpp
@@ -85,7 +85,7 @@ namespace argparse {
 
         std::stringstream ss;
         ss << "\n";
-        for(auto& line : wrap_width(parser_->description(), total_width_)) {
+        for(auto& line : wrap_width(parser_->description(), total_width_, {" ", "/"})) {
             ss << line;
         }
         ss << "\n";
@@ -132,7 +132,7 @@ namespace argparse {
                     }
                     
                     //Argument help
-                    auto help_lines = wrap_width(arg->help(), total_width_ - option_name_width_);
+                    auto help_lines = wrap_width(arg->help(), total_width_ - option_name_width_, {" ", "/"});
                     for (auto& line : help_lines) {
                         //Pad out the help
                         assert(pos <= option_name_width_);
@@ -156,7 +156,7 @@ namespace argparse {
                 if (!group.epilog().empty()) {
                     ss << "\n";
 
-                    auto epilog_lines = wrap_width(group.epilog(), total_width_ - INDENT.size());
+                    auto epilog_lines = wrap_width(group.epilog(), total_width_ - INDENT.size(), {" ", "/"});
                     for (auto& line : epilog_lines) {
                         ss << INDENT << line;
                     }
@@ -173,7 +173,7 @@ namespace argparse {
 
         std::stringstream ss;
         ss << "\n";
-        for(auto& line : wrap_width(parser_->epilog(), total_width_)) {
+        for(auto& line : wrap_width(parser_->epilog(), total_width_, {" ", "/"})) {
             ss << line;
         }
         ss << "\n";

--- a/src/argparse_util.hpp
+++ b/src/argparse_util.hpp
@@ -35,7 +35,7 @@ namespace argparse {
 
     char* strdup(const char* str);
 
-    std::vector<std::string> wrap_width(std::string str, size_t width, std::vector<std::string> split_str={" ", "/"});
+    std::vector<std::string> wrap_width(std::string str, size_t width, std::vector<std::string> split_str);
 
     std::string basename(std::string filepath);
 } //namespace


### PR DESCRIPTION
Hi Kevin,
   I have tested the patch on Mac OS Mojave 10.14.4 with AppleClang 10.0.1.10010046.
   The example executables argparse_test and argparse_example are working well.
   So I try this pull request.

   Best regards,
   Xifan Tang