### PR TITLE
argparse_util.hpp uses std::string. Include <string>

### DIFF
--- a/src/argparse_util.hpp
+++ b/src/argparse_util.hpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include <map>
 #include <memory>
+#include <string>
 
 namespace argparse {
     class Argument;


### PR DESCRIPTION
Adding missing include.