### PR TITLE
Tiny cleanup: prefer more efficient find(char).

### DIFF
--- a/src/argparse_util.cpp
+++ b/src/argparse_util.cpp
@@ -117,10 +117,10 @@ namespace argparse {
     std::string basename(std::string filepath) {
 #ifdef _WIN32
         //Windows uses back-slash as directory divider
-        auto pos = filepath.rfind("\\");
+        auto pos = filepath.rfind('\\');
 #else
         //*nix-like uses forward-slash as directory divider
-        auto pos = filepath.rfind("/");
+        auto pos = filepath.rfind('/');
 #endif
         if (pos == std::string::npos) {
             pos = 0;


### PR DESCRIPTION
We're only looking for one character, use the specialized
function for that.

Signed-off-by: Henner Zeller <h.zeller@acm.org>